### PR TITLE
Add heatmap server

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Signal Heatmap</title>
+  <link rel="stylesheet" href="https://unpkg.com/leaflet/dist/leaflet.css" />
+  <style>
+    html, body, #map { height: 100%; margin: 0; }
+  </style>
+</head>
+<body>
+  <div id="map"></div>
+
+  <script src="https://unpkg.com/leaflet/dist/leaflet.js"></script>
+  <script src="https://unpkg.com/leaflet.heat/dist/leaflet-heat.js"></script>
+  <script>
+    fetch('/data')
+      .then(r => r.json())
+      .then(raw => {
+        const items = Array.isArray(raw) ? raw : [raw];
+        const points = items.map(i => [i.latitude, i.longitude, (i.scan_result && i.scan_result.signal_quality ? i.scan_result.signal_quality / 100 : 0.5)]);
+        const map = L.map('map').setView([0, 0], 2);
+        L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+          attribution: '© OpenStreetMap contributors'
+        }).addTo(map);
+        if (points.length) {
+          const avgLat = points.reduce((a, p) => a + p[0], 0) / points.length;
+          const avgLng = points.reduce((a, p) => a + p[1], 0) / points.length;
+          map.setView([avgLat, avgLng], 13);
+          L.heatLayer(points, { radius: 25 }).addTo(map);
+        }
+      })
+      .catch(err => console.error('Failed to load data', err));
+  </script>
+</body>
+</html>

--- a/readme.txt
+++ b/readme.txt
@@ -1,1 +1,3 @@
-readme
+# Heatmap Demo
+
+Run `python3 server.py` and open `http://localhost:8500` in your browser. The page reads `/home/pi/test_results.json` and displays the signal scan results with a Leaflet heatmap.

--- a/server.py
+++ b/server.py
@@ -1,0 +1,32 @@
+import http.server
+import socketserver
+import json
+import pathlib
+
+PORT = 8500
+
+class Handler(http.server.SimpleHTTPRequestHandler):
+    def do_GET(self):
+        if self.path == '/data':
+            file_path = pathlib.Path('/home/pi/test_results.json')
+            if file_path.exists():
+                try:
+                    with file_path.open() as f:
+                        data = json.load(f)
+                except Exception:
+                    data = []
+            else:
+                data = []
+            self.send_response(200)
+            self.send_header('Content-Type', 'application/json')
+            self.end_headers()
+            self.wfile.write(json.dumps(data).encode())
+        else:
+            if self.path == '/':
+                self.path = '/index.html'
+            return http.server.SimpleHTTPRequestHandler.do_GET(self)
+
+if __name__ == '__main__':
+    with socketserver.TCPServer(('', PORT), Handler) as httpd:
+        print(f'Serving on port {PORT}')
+        httpd.serve_forever()


### PR DESCRIPTION
## Summary
- serve index.html on port 8500 with a small Python HTTP server
- use Leaflet and leaflet.heat to display `/home/pi/test_results.json`
- document running the server

## Testing
- `python3 -m py_compile server.py`

------
https://chatgpt.com/codex/tasks/task_e_686e0a52587083259676b7fe8f49ba6e