### PR TITLE
Add test data and load from repo

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,8 @@
   <script src="https://unpkg.com/leaflet/dist/leaflet.js"></script>
   <script src="https://unpkg.com/leaflet.heat/dist/leaflet-heat.js"></script>
   <script>
-    fetch('/data') <!-- Updated to match the server endpoint -->
+    // Load test data from the bundled JSON file
+    fetch('test_results.json')
       .then(r => r.json())
       .then(raw => {
         const items = Array.isArray(raw) ? raw : [raw];

--- a/readme.txt
+++ b/readme.txt
@@ -1,3 +1,3 @@
 # Heatmap Demo
 
-Run `python3 server.py` and open `http://localhost:8500` in your browser. The page reads `/home/pi/test_results.json` and displays the signal scan results with a Leaflet heatmap.
+Run `python3 server.py` and open `http://localhost:8500` in your browser. The page reads `test_results.json` bundled with this repo and displays the signal scan results with a Leaflet heatmap.

--- a/server.py
+++ b/server.py
@@ -8,12 +8,14 @@ import sys
 import time
 
 PORT = 8500
-BASE_DIR = pathlib.Path('/home/pi/heatmap')  # Base directory for the server
+# Base directory for the server (folder containing this script)
+BASE_DIR = pathlib.Path(__file__).resolve().parent
 
 class Handler(http.server.SimpleHTTPRequestHandler):
     def do_GET(self):
         if self.path == '/data':
-            file_path = pathlib.Path('/test_results.json')
+            # Load test results from a JSON file located in BASE_DIR
+            file_path = BASE_DIR / 'test_results.json'
             if file_path.exists():
                 try:
                     with file_path.open() as f:

--- a/test_results.json
+++ b/test_results.json
@@ -1,0 +1,57 @@
+[
+  { 
+    "timestamp": 1752012279,
+    "type": "speedtest",
+    "scan_result": {
+      "ssid": "APN staff",
+      "bssid": "B4:A2:5C:76:66:70",
+      "signal_quality": 59
+    },
+    "speedtest": {
+      "ping_ms": 34.017,
+      "download_mbps": 86.56,
+      "upload_mbps": 33.83,
+      "server": "AARNet",
+      "bssid": "B4:A2:5C:76:66:70",
+      "rssi_dbm": -61
+    },
+    "browser_load_times_ms": {
+      "https://www.google.com": 411.88,
+      "https://www.yahoo.com": 172.7,
+      "https://www.bom.gov.au": 180.72
+    }
+  },
+  {
+    "timestamp": 1752012300,
+    "type": "signal_scan",
+    "latitude": -37.865182191674634,
+    "longitude": 145.04814371589615,
+    "scan_result": {
+      "ssid": "APN staff",
+      "bssid": "B4:A2:5C:76:66:70",
+      "signal_quality": 57
+    }
+  },
+  {
+    "timestamp": 1752012310,
+    "type": "signal_scan",
+    "latitude": -37.736261993075075,
+    "longitude": 144.99572430239303,
+    "scan_result": {
+      "ssid": "APN staff",
+      "bssid": "B4:A2:5C:76:66:70",
+      "signal_quality": 59
+    }
+  },
+  {
+    "timestamp": 1752012320,
+    "type": "signal_scan",
+    "latitude": -37.74439073416801,
+    "longitude": 145.0056279899392,
+    "scan_result": {
+      "ssid": "APN staff",
+      "bssid": "B4:A2:5C:76:66:70",
+      "signal_quality": 59
+    }
+  }
+]


### PR DESCRIPTION
## Summary
- add `test_results.json` with example data
- load test results from this file in the server
- fetch `test_results.json` directly in the heatmap page
- update README to describe new behavior

## Testing
- `python3 -m py_compile server.py`

------
https://chatgpt.com/codex/tasks/task_e_686e1f198ad48325b00548256e1fc26c