### PR TITLE
Fix root path not serving index.html

### DIFF
--- a/server.py
+++ b/server.py
@@ -32,7 +32,6 @@ class Handler(http.server.SimpleHTTPRequestHandler):
             # Serve static files (e.g., index.html)
             if self.path == '/':
                 self.path = '/index.html'
-            self.path = str(BASE_DIR / self.path.lstrip('/'))
             return http.server.SimpleHTTPRequestHandler.do_GET(self)
 
 def find_and_kill_existing_process(port):
@@ -86,6 +85,9 @@ if __name__ == '__main__':
 
     # Check if the port is already in use and kill the process if necessary
     find_and_kill_existing_process(PORT)
+
+    # Ensure that the HTTP server serves files from this directory
+    os.chdir(BASE_DIR)
 
     # Start the server
     start_server()


### PR DESCRIPTION
## Summary
- fix 404 issue for `/` by not translating the path to an absolute
- force working directory to the repo's base before launching the HTTP server

## Testing
- `python3 -m py_compile server.py`
- `python3 server.py & sleep 1; curl -I http://localhost:8500/; kill $!; wait $! 2>/dev/null`

------
https://chatgpt.com/codex/tasks/task_e_686e20cda39083258c22097099d2fc2c